### PR TITLE
Add view state to post list feature

### DIFF
--- a/Toybox/Features/PostList/PostListView.swift
+++ b/Toybox/Features/PostList/PostListView.swift
@@ -40,6 +40,11 @@ struct PostListView: View {
                 EmptyView()
                 
             case .loading:
+                // maybe explore using `.overlay` instead? Might not be
+                // compatible with how we use a state enum though
+                // Pointfree has an interesting way of doing this
+                // for swiftui's state based navigation with enums,
+                // but requires their navigation package/library
                 ProgressView {
                     Text("Loading posts")
                 }
@@ -63,6 +68,18 @@ struct PostListView: View {
                 Text(post.title)
             }
         }
+        /*
+         Refreshable here is a bit buggy due to the `fetchPosts()` method
+         updating the view state multiple times - once to set the state to loading
+         and another to either set it to success/error. Thus, when we trigger
+         `fetchPosts()`, the view gets redrawn almost immediately due to the
+         view model's state binding being updated.
+         */
+//        .refreshable {
+//            Task {
+//                await viewModel.fetchPosts()
+//            }
+//        }
     }
 }
 

--- a/Toybox/Features/PostList/PostListView.swift
+++ b/Toybox/Features/PostList/PostListView.swift
@@ -13,14 +13,55 @@ struct PostListView: View {
     
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(viewModel.posts) { post in
-                    Text(post.title)
+            containerView
+                .navigationTitle("Posts")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Refresh") {
+                            Task {
+                                await viewModel.fetchPosts()
+                            }
+                        }
+                    }
                 }
-            }
         }
         .task {
             await viewModel.fetchPosts()
+        }
+    }
+    
+    @ViewBuilder
+    var containerView: some View {
+        switch viewModel.state {
+            case .initial:
+                // in theory, we would have some base view with
+                // skeleton views here that shimmer to replicate some
+                // data that hasn't loaded yet
+                EmptyView()
+                
+            case .loading:
+                ProgressView {
+                    Text("Loading posts")
+                }
+                
+            case .empty:
+                Text("No posts available!")
+                
+            case .success(let posts):
+                postListView(posts)
+                
+            case .error(let error):
+                Text("Error loading posts - \(error)")
+                
+        }
+    }
+    
+    @ViewBuilder
+    func postListView(_ posts: [Post]) -> some View {
+        List {
+            ForEach(posts) { post in
+                Text(post.title)
+            }
         }
     }
 }

--- a/Toybox/Features/PostList/PostListViewModel.swift
+++ b/Toybox/Features/PostList/PostListViewModel.swift
@@ -9,21 +9,35 @@ import Foundation
 
 final class PostListViewModel: ObservableObject {
     
+    // not sure if we want to keep this as a property here for the view
+    // to use or if we want to only allow the view to access these items
+    // through the success view state
+//    @Published private(set) var posts: [Post] = []
+    @Published private(set) var state: ViewState = .initial
     let postProvider: PostProvider
     
     init(postProvider: PostProvider) {
         self.postProvider = postProvider
     }
     
-    @Published var posts: [Post] = []
+    enum ViewState {
+        case initial
+        case loading
+        case empty
+        case success(posts: [Post])
+        case error(_ error: String)
+    }
     
     @MainActor
     func fetchPosts() async {
+        state = .loading
         do {
+            // delay task to show off loading animation
+            try await Task.sleep(for: .seconds(1))
             let posts = try await postProvider.fetchPosts()
-            self.posts = posts
+            state = .success(posts: posts)
         } catch {
-            print(error)
+            state = .error(error.localizedDescription)
         }
     }
 }


### PR DESCRIPTION
Reference used: https://conradstoll.com/blog/state-driven-development

Added some view state for the post list feature. Current issues still are handling some `.refreshable` logic and `.alert` logic for showing errors in an alert. 

For the `.refreshable` portion, the issue is that in the method that we should use to refresh (`viewModel.fetchPosts()`), it updates our `@Published` state variable twice: once before the network request to switch our context into loading and then once more after our network request finishes to update the state into either success or failure/error. Since SwiftUI redraws our views on updates to `@Published` variables, it does so on the first state change, instead of only on post changes in this case (we still want the loading for other scenarios though). Perhaps this: https://showmax.engineering/articles/unexpected-redrawing-in-swiftui might help?

For the alert logic, this has to do with how we store our state. Since we are storing our state in an enum, our enum becomes our published variable. Normally, you need to pass some published state bool for alerts so that the compiler knows when to show the alert (and it will also take care of toggling it back once we dismiss the alert). In this case, we don't have some boolean to tell when an alert should be shown. We can add a computed variable to our enum and switch on it to return true if we are in the error case, but this would not be a published state variable then. Not sure how to resolve this. Pointfree has a library for state based navigation that potentially handles this by allowing alerts to show based on an enum (https://www.pointfree.co/blog/posts/96-modern-swiftui-state-driven-navigation). Should come back to this later